### PR TITLE
Permit public access for auth registration endpoint

### DIFF
--- a/auth-service/src/main/java/com/auth/service/config/SecurityConfig.java
+++ b/auth-service/src/main/java/com/auth/service/config/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.auth.service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/auth/register", "/auth/login").permitAll()
+                .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}

--- a/auth-service/src/main/java/com/auth/service/controller/AuthController.java
+++ b/auth-service/src/main/java/com/auth/service/controller/AuthController.java
@@ -1,0 +1,16 @@
+package com.auth.service.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    @PostMapping("/register")
+    public ResponseEntity<String> register() {
+        return ResponseEntity.ok("registered");
+    }
+}

--- a/gateway-service/src/main/java/com/abc/gateway_service/SecurityConfig.java
+++ b/gateway-service/src/main/java/com/abc/gateway_service/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.abc.gateway_service;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/auth/register", "/auth/login").permitAll()
+                .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}


### PR DESCRIPTION
## Summary
- configure security in gateway-service and auth-service to allow unauthenticated access to /auth/register and /auth/login
- add minimal AuthController with stub /auth/register endpoint

## Testing
- `mvn test` (gateway-service) - failed: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 (Network is unreachable)
- `mvn test` (auth-service) - failed: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 (Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68aeeaebe69c832e97e156aa89ff562e