### PR TITLE
Allow gateway requests without security restrictions

### DIFF
--- a/gateway-service/src/main/java/com/abc/gateway_service/config/SecurityConfig.java
+++ b/gateway-service/src/main/java/com/abc/gateway_service/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.abc.gateway_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .authorizeHttpRequests(authorize -> authorize
+                        .anyRequest().permitAll()
+                )
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Add SecurityConfig to gateway service to disable CSRF, enable CORS, and permit all requests.

## Testing
- `mvn test` *(fails: Non-resolvable parent POM because https://repo.maven.apache.org/maven2 is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aef7f3b288832e8b90bc0905500247